### PR TITLE
Fix: use -snconf for systemnode config file name

### DIFF
--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -792,7 +792,7 @@ fs::path GetMasternodeConfigFile()
 
 fs::path GetSystemnodeConfigFile()
 {
-    fs::path pathConfigFile(gArgs.GetArg("-mnconf", "systemnode.conf"));
+    fs::path pathConfigFile(gArgs.GetArg("-snconf", "systemnode.conf"));
     return AbsPathForConfigVal(pathConfigFile, false);
 }
 


### PR DESCRIPTION
Use -snconf to name systemnode config file from command line. Default name is fine but could not be overridden previously