### PR TITLE
Hmm

### DIFF
--- a/src/masternode/masternode.cpp
+++ b/src/masternode/masternode.cpp
@@ -641,6 +641,8 @@ bool CMasternodeBroadcast::CheckAndUpdate(int& nDos) const
 
 bool CMasternodeBroadcast::CheckInputsAndAdd(int& nDoS) const
 {
+    LogPrintf("%s - 1\n", __func__);
+
     // we are a masternode with the same vin (i.e. already activated) and this mnb is ours (matches our Masternode privkey)
     // so nothing to do here for us
     if(fMasterNode && vin.prevout == activeMasternode.vin.prevout && pubkey2 == activeMasternode.pubKeyMasternode)
@@ -649,6 +651,8 @@ bool CMasternodeBroadcast::CheckInputsAndAdd(int& nDoS) const
     // incorrect ping or its sigTime
     if(lastPing == CMasternodePing() || !lastPing.CheckAndUpdate(nDoS, false, true))
         return false;
+        
+    LogPrintf("%s - 2\n", __func__);
 
     // search existing Masternode list
     CMasternode* pmn = mnodeman.Find(vin);

--- a/src/systemnode/systemnodeman.cpp
+++ b/src/systemnode/systemnodeman.cpp
@@ -72,8 +72,7 @@ std::vector<std::pair<int, CSystemnode> > CSystemnodeMan::GetSystemnodeRanks(int
     if(!GetBlockHash(hash, nBlockHeight)) return vecSystemnodeRanks;
 
     // scan for winner
-    for (auto& sn : vSystemnodes)
-    {
+    for (auto& sn : vSystemnodes) {
         sn.Check();
         if(sn.protocolVersion < minProtocol) continue;
         if(!sn.IsEnabled())
@@ -84,7 +83,7 @@ std::vector<std::pair<int, CSystemnode> > CSystemnodeMan::GetSystemnodeRanks(int
     sort(vecSystemnodeScores.rbegin(), vecSystemnodeScores.rend(), CompareScoreSN());
 
     int rank = 0;
-     for (const auto& s : vecSystemnodeScores) {
+    for (const auto& s : vecSystemnodeScores) {
         rank++;
         vecSystemnodeRanks.push_back(std::make_pair(rank, s.second));
     }
@@ -100,19 +99,41 @@ void CSystemnodeMan::ProcessSystemnodeConnections()
     for (const auto& pnode : g_connman->CopyNodeVector()) {
         if(pnode->fSystemnode) {
             if(legacySigner.pSubmittedToSystemnode != NULL && pnode->addr == legacySigner.pSubmittedToSystemnode->addr) continue;
-            LogPrint(BCLog::NET, "Closing Systemnode connection %s \n", pnode->addr.ToString());
+            LogPrint(BCLog::SYSTEMNODE, "Closing Systemnode connection %s \n", pnode->addr.ToString());
             pnode->fSystemnode = false;
             pnode->Release();
         }
     }
 }
 
+void CSystemnodeMan::AskForSN(CNode* pnode, CTxIn &vin)
+{
+    std::map<COutPoint, int64_t>::iterator i = mWeAskedForSystemnodeListEntry.find(vin.prevout);
+    if (i != mWeAskedForSystemnodeListEntry.end()) {
+        int64_t t = (*i).second;
+        if (GetTime() < t) return; // we've asked recently
+    }
+
+    // ask for the snb info once from the node that sent snp
+    LogPrint(BCLog::SYSTEMNODE, "CSystemnodeMan::AskForSN - Asking node for missing entry, vin: %s\n", vin.ToString());
+    const CNetMsgMaker msgMaker(PROTOCOL_VERSION);
+    g_connman->PushMessage(pnode, msgMaker.Make("sndseg", vin));
+    int64_t askAgain = GetTime() + SYSTEMNODE_MIN_SNP_SECONDS;
+    mWeAskedForSystemnodeListEntry[vin.prevout] = askAgain;
+}
+
+void CSystemnodeMan::Check()
+{
+    LOCK(cs);
+
+    for (auto& sn : vSystemnodes) {
+        sn.Check();
+    }
+}
+
 void CSystemnodeMan::ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman* connman)
 {
-    if (!gArgs.GetBoolArg("-jumpstart", false))
-    {
-        if(!systemnodeSync.IsBlockchainSynced()) return;
-    }
+    LOCK(cs_process_message);
 
     //! systemnode broadcast
     if (strCommand == NetMsgType::SNBROADCAST) {
@@ -191,7 +212,7 @@ void CSystemnodeMan::ProcessMessage(CNode* pfrom, const std::string& strCommand,
                     nInvCount++;
                     if(!mapSeenSystemnodeBroadcast.count(hash)) mapSeenSystemnodeBroadcast.insert(std::make_pair(hash, snb));
                     if(vin == sn.vin) {
-                        LogPrint(BCLog::NET, "sndseg - Sent 1 Systemnode entries to %s\n", pfrom->addr.ToString());
+                        LogPrint(BCLog::SYSTEMNODE, "sndseg - Sent 1 Systemnode entries to %s\n", pfrom->addr.LegacyToString());
                         return;
                     }
                 }
@@ -201,348 +222,9 @@ void CSystemnodeMan::ProcessMessage(CNode* pfrom, const std::string& strCommand,
         if(vin == CTxIn()) {
             const CNetMsgMaker msgMaker(PROTOCOL_VERSION);
             g_connman->PushMessage(pfrom, msgMaker.Make("snssc", SYSTEMNODE_SYNC_LIST, nInvCount));
-            LogPrint(BCLog::NET, "sndseg - Sent %d Systemnode entries to %s\n", nInvCount, pfrom->addr.ToString());
+            LogPrint(BCLog::SYSTEMNODE, "sndseg - Sent %d Systemnode entries to %s\n", nInvCount, pfrom->addr.LegacyToString());
         }
     }
-
-}
-
-void CSystemnodeMan::AskForSN(CNode* pnode, CTxIn &vin)
-{
-    std::map<COutPoint, int64_t>::iterator i = mWeAskedForSystemnodeListEntry.find(vin.prevout);
-    if (i != mWeAskedForSystemnodeListEntry.end()) {
-        int64_t t = (*i).second;
-        if (GetTime() < t) return; // we've asked recently
-    }
-
-    // ask for the snb info once from the node that sent snp
-    LogPrint(BCLog::NET, "CSystemnodeMan::AskForSN - Asking node for missing entry, vin: %s\n", vin.ToString());
-    const CNetMsgMaker msgMaker(PROTOCOL_VERSION);
-    g_connman->PushMessage(pnode, msgMaker.Make("sndseg", vin));
-    int64_t askAgain = GetTime() + SYSTEMNODE_MIN_SNP_SECONDS;
-    mWeAskedForSystemnodeListEntry[vin.prevout] = askAgain;
-}
-
-bool CSystemnodeMan::CheckSnbAndUpdateSystemnodeList(CSystemnodeBroadcast snb, int& nDos)
-{
-    nDos = 0;
-    LogPrint(BCLog::NET, "CSystemnodeMan::CheckSnbAndUpdateSystemnodeList - Systemnode broadcast, vin: %s\n", snb.vin.ToString());
-
-    auto snbHash = snb.GetHash();
-    if(mapSeenSystemnodeBroadcast.count(snbHash)) { //seen
-        systemnodeSync.AddedSystemnodeList(snbHash);
-        return true;
-    }
-    mapSeenSystemnodeBroadcast.insert(std::make_pair(snbHash, snb));
-
-    LogPrint(BCLog::NET, "CSystemnodeMan::CheckSnbAndUpdateSystemnodeList - Systemnode broadcast, vin: %s new\n", snb.vin.ToString());
-    // We check addr before both initial snb and update
-    if(!snb.IsValidNetAddr()) {
-        LogPrint(BCLog::NET, "CMasternodeBroadcast::CheckSnbAndUpdateMasternodeList -- Invalid addr, rejected: masternode=%s  sigTime=%lld  addr=%s\n",
-                    snb.vin.prevout.ToStringShort(), snb.sigTime, snb.addr.ToString());
-        return false;
-    }
-
-    if (mnodeman.Find(snb.addr) != NULL) {
-        LogPrint(BCLog::NET, "CSystemnodeMan::CheckSnbAndUpdateSystemnodeList - There is already a masternode with the same ip: %s\n", snb.addr.ToString());
-        return false;
-    }
-
-    if(!snb.CheckAndUpdate(nDos)) {
-        LogPrint(BCLog::NET, "CSystemnodeMan::CheckSnbAndUpdateSystemnodeList - Systemnode broadcast, vin: %s CheckAndUpdate failed\n", snb.vin.ToString());
-        return false;
-    }
-
-    // make sure the vout that was signed is related to the transaction that spawned the Systemnode
-    //  - this is expensive, so it's only done once per Systemnode
-    if (!legacySigner.IsVinAssociatedWithPubkey(snb.vin, snb.pubkey, 1, Params().GetConsensus())) {
-        LogPrint(BCLog::SYSTEMNODE, "CSystemnodeMan::CheckSnbAndUpdateSystemnodeList - Got mismatched pubkey and vin\n");
-        return false;
-    }
-
-    // make sure it's still unspent
-    //  - this is checked later by .check() in many places and by ThreadCheckDarkSendPool()
-    if(snb.CheckInputsAndAdd(nDos)) {
-        systemnodeSync.AddedSystemnodeList(snbHash);
-    } else {
-        LogPrint(BCLog::NET, "CSystemnodeMan::CheckSnbAndUpdateSystemnodeList - Rejected Systemnode entry %s\n", snb.addr.ToString());
-        return false;
-    }
-
-    return true;
-}
-
-CSystemnode *CSystemnodeMan::Find(const CTxIn &vin)
-{
-    LOCK(cs);
-
-    for (auto& sn : vSystemnodes) {
-        if(sn.vin.prevout == vin.prevout)
-            return &sn;
-    }
-    return NULL;
-}
-
-CSystemnode *CSystemnodeMan::Find(const CPubKey &pubKeySystemnode)
-{
-    LOCK(cs);
-
-    for (auto& sn : vSystemnodes) {
-        if(sn.pubkey2 == pubKeySystemnode)
-            return &sn;
-    }
-    return NULL;
-}
-
-CSystemnode *CSystemnodeMan::Find(const CService& addr)
-{
-    LOCK(cs);
-
-    for (auto& sn : vSystemnodes) {
-        if(sn.addr == addr)
-            return &sn;
-    }
-    return NULL;
-}
-
-// 
-// Deterministically select the oldest/best systemnode to pay on the network
-//
-CSystemnode* CSystemnodeMan::GetNextSystemnodeInQueueForPayment(int nBlockHeight, bool fFilterSigTime, int& nCount)
-{
-    LOCK(cs);
-
-    CSystemnode *pBestSystemnode = NULL;
-    std::vector<std::pair<int64_t, CTxIn> > vecSystemnodeLastPaid;
-
-    /*
-        Make a vector with all of the last paid times
-    */
-
-    int nSnCount = CountEnabled();
-    for (auto& sn : vSystemnodes)
-    {
-        sn.Check();
-        if(!sn.IsEnabled()) continue;
-
-        // check protocol version
-        if(sn.protocolVersion < systemnodePayments.GetMinSystemnodePaymentsProto()) continue;
-
-        //it's in the list (up to 8 entries ahead of current block to allow propagation) -- so let's skip it
-        if(systemnodePayments.IsScheduled(sn, nBlockHeight)) continue;
-
-        // For security reasons and for network stability there is a delay to get the first reward.
-        // The time is calculated as a product of 60 block and node count.
-        if(fFilterSigTime && sn.sigTime + (nSnCount * 1 * 60) > GetAdjustedTime()) continue;
-
-        //make sure it has as many confirmations as there are systemnodes
-        if(sn.GetSystemnodeInputAge() < nSnCount) continue;
-
-        vecSystemnodeLastPaid.push_back(std::make_pair(sn.SecondsSincePayment(), sn.vin));
-    }
-
-    nCount = (int)vecSystemnodeLastPaid.size();
-
-    //when the network is in the process of upgrading, don't penalize nodes that recently restarted
-    if(fFilterSigTime && nCount < nSnCount/3) return GetNextSystemnodeInQueueForPayment(nBlockHeight, false, nCount);
-
-    // Sort them high to low
-    sort(vecSystemnodeLastPaid.rbegin(), vecSystemnodeLastPaid.rend(), CompareLastPaid());
-
-    // Look at 1/10 of the oldest nodes (by last payment), calculate their scores and pay the best one
-    //  -- This doesn't look at who is being paid in the +8-10 blocks, allowing for double payments very rarely
-    //  -- 1/100 payments should be a double payment on mainnet - (1/(3000/10))*2
-    //  -- (chance per block * chances before IsScheduled will fire)
-    int nTenthNetwork = CountEnabled()/10;
-    int nCountTenth = 0; 
-    arith_uint256 nHigh = 0;
-    for (auto& s : vecSystemnodeLastPaid) {
-        CSystemnode* pmn = Find(s.second);
-        if(!pmn) break;
-
-        arith_uint256 n = pmn->CalculateScore(nBlockHeight-100);
-        if(n > nHigh){
-            nHigh = n;
-            pBestSystemnode = pmn;
-        }
-        nCountTenth++;
-        if(nCountTenth >= nTenthNetwork) break;
-    }
-    return pBestSystemnode;
-}
-
-bool CSystemnodeMan::Add(CSystemnode &sn)
-{
-    LOCK(cs);
-
-    if (!sn.IsEnabled())
-        return false;
-
-    CSystemnode *psn = Find(sn.vin);
-    if (!psn) {
-        LogPrint(BCLog::NET, "CSystemnodeMan: Adding new Systemnode %s - %i now\n", sn.addr.ToString(), size() + 1);
-        vSystemnodes.push_back(sn);
-        return true;
-    }
-
-    return false;
-}
-
-void CSystemnodeMan::UpdateSystemnodeList(CSystemnodeBroadcast snb)
-{
-    auto snbHash = snb.GetHash();
-    mapSeenSystemnodePing.insert(std::make_pair(snb.lastPing.GetHash(), snb.lastPing));
-    mapSeenSystemnodeBroadcast.insert(std::make_pair(snbHash, snb));
-    systemnodeSync.AddedSystemnodeList(snbHash);
-
-    LogPrint(BCLog::SYSTEMNODE, "CSystemnodeMan::UpdateSystemnodeList() - addr: %s\n    vin: %s\n", snb.addr.ToString(), snb.vin.ToString());
-
-    CSystemnode* psn = Find(snb.vin);
-    if (!psn) {
-        CSystemnode sn(snb);
-        Add(sn);
-    } else {
-        psn->UpdateFromNewBroadcast(snb);
-    }
-}
-
-void CSystemnodeMan::Remove(CTxIn vin)
-{
-    LOCK(cs);
-
-    std::vector<CSystemnode>::iterator it = vSystemnodes.begin();
-    while(it != vSystemnodes.end()){
-        if((*it).vin == vin){
-            LogPrint(BCLog::NET, "CSystemnodeMan: Removing Systemnode %s - %i now\n", (*it).addr.ToString(), size() - 1);
-            vSystemnodes.erase(it);
-            break;
-        }
-        ++it;
-    }
-}
-
-int CSystemnodeMan::CountEnabled(int protocolVersion)
-{
-    int i = 0;
-    protocolVersion = protocolVersion == -1 ? systemnodePayments.GetMinSystemnodePaymentsProto() : protocolVersion;
-
-    for (auto& sn : vSystemnodes) {
-        sn.Check();
-        if(sn.protocolVersion < protocolVersion || !sn.IsEnabled()) continue;
-        i++;
-    }
-
-    return i;
-}
-
-void CSystemnodeMan::DsegUpdate(CNode* pnode)
-{
-    LOCK(cs);
-
-    if(Params().NetworkIDString() == CBaseChainParams::MAIN) {
-        if(!(pnode->addr.IsRFC1918() || pnode->addr.IsLocal())){
-            std::map<CNetAddr, int64_t>::iterator it = mWeAskedForSystemnodeList.find(pnode->addr);
-            if (it != mWeAskedForSystemnodeList.end()) {
-                if (GetTime() < (*it).second) {
-                    LogPrint(BCLog::NET, "sndseg - we already asked %s for the list; skipping...\n", pnode->addr.ToString());
-                    return;
-                }
-            }
-        }
-    }
-    
-    const CNetMsgMaker msgMaker(PROTOCOL_VERSION);
-    g_connman->PushMessage(pnode, msgMaker.Make("sndseg", CTxIn()));
-    int64_t askAgain = GetTime() + SYSTEMNODES_DSEG_SECONDS;
-    mWeAskedForSystemnodeList[pnode->addr] = askAgain;
-}
-
-std::string CSystemnodeMan::ToString() const
-{
-    std::ostringstream info;
-
-    info << "Systemnodes: " << (int)vSystemnodes.size() <<
-            ", peers who asked us for Systemnode list: " << (int)mAskedUsForSystemnodeList.size() <<
-            ", peers we asked for Systemnode list: " << (int)mWeAskedForSystemnodeList.size() <<
-            ", entries in Systemnode list we asked for: " << (int)mWeAskedForSystemnodeListEntry.size();
-
-    return info.str();
-}
-
-void CSystemnodeMan::Clear()
-{
-    LOCK(cs);
-    vSystemnodes.clear();
-    mAskedUsForSystemnodeList.clear();
-    mWeAskedForSystemnodeList.clear();
-    mWeAskedForSystemnodeListEntry.clear();
-    mapSeenSystemnodeBroadcast.clear();
-    mapSeenSystemnodePing.clear();
-}
-
-void CSystemnodeMan::Check()
-{
-    LOCK(cs);
-
-    for (auto& sn : vSystemnodes) {
-        sn.Check();
-    }
-}
-
-CSystemnode* CSystemnodeMan::GetCurrentSystemNode(int mod, int64_t nBlockHeight, int minProtocol)
-{
-    int64_t score = 0;
-    CSystemnode* winner = NULL;
-
-    // scan for winner
-    for (auto& mn : vSystemnodes) {
-        mn.Check();
-        if(mn.protocolVersion < minProtocol || !mn.IsEnabled()) continue;
-
-        // calculate the score for each Systemnode
-        int64_t n2 = mn.CalculateScore(nBlockHeight).GetCompact(false);
-
-        // determine the winner
-        if(n2 > score){
-            score = n2;
-            winner = &mn;
-        }
-    }
-
-    return winner;
-}
-
-int CSystemnodeMan::GetSystemnodeRank(const CTxIn& vin, int64_t nBlockHeight, int minProtocol, bool fOnlyActive)
-{
-    std::vector<std::pair<int64_t, CTxIn> > vecSystemnodeScores;
-
-    //make sure we know about this block
-    uint256 hash = uint256();
-    if(!GetBlockHash(hash, nBlockHeight)) return -1;
-
-    // scan for winner
-    for (auto& sn : vSystemnodes) {
-        if(sn.protocolVersion < minProtocol) continue;
-        if(fOnlyActive) {
-            sn.Check();
-            if(!sn.IsEnabled()) continue;
-        }
-        int64_t n2 = sn.CalculateScore(nBlockHeight).GetCompact(false);
-
-        vecSystemnodeScores.push_back(std::make_pair(n2, sn.vin));
-    }
-
-    sort(vecSystemnodeScores.rbegin(), vecSystemnodeScores.rend(), CompareScoreTxIn());
-
-    int rank = 0;
-    for (auto& s : vecSystemnodeScores) {
-        rank++;
-        if(s.second.prevout == vin.prevout) {
-            return rank;
-        }
-    }
-
-    return -1;
 }
 
 void CSystemnodeMan::CheckAndRemove(bool forceExpiredRemoval)
@@ -558,10 +240,10 @@ void CSystemnodeMan::CheckAndRemove(bool forceExpiredRemoval)
                 (*it).activeState == CSystemnode::SYSTEMNODE_VIN_SPENT ||
                 (forceExpiredRemoval && (*it).activeState == CSystemnode::SYSTEMNODE_EXPIRED) ||
                 (*it).protocolVersion < systemnodePayments.GetMinSystemnodePaymentsProto()) {
-            LogPrint(BCLog::NET, "CSystemnodeMan: Removing inactive Systemnode %s - %i now\n", (*it).addr.ToString(), size() - 1);
+            LogPrint(BCLog::SYSTEMNODE, "CSystemnodeMan: Removing inactive Systemnode %s - %i now\n", (*it).addr.LegacyToString(), size() - 1);
 
             //erase all of the broadcasts we've seen from this vin
-            // -- if we missed a few pings and the node was removed, this will allow is to get it back without them 
+            // -- if we missed a few pings and the node was removed, this will allow is to get it back without them
             //    sending a brand new snb
             std::map<uint256, CSystemnodeBroadcast>::iterator it3 = mapSeenSystemnodeBroadcast.begin();
             while(it3 != mapSeenSystemnodeBroadcast.end()){
@@ -623,7 +305,7 @@ void CSystemnodeMan::CheckAndRemove(bool forceExpiredRemoval)
     auto it3 = mapSeenSystemnodeBroadcast.begin();
     while(it3 != mapSeenSystemnodeBroadcast.end()){
         if((*it3).second.lastPing.sigTime < GetTime() - SYSTEMNODE_REMOVAL_SECONDS*2){
-            LogPrint(BCLog::NET, "CSystemnodeMan::CheckAndRemove - Removing expired Systemnode broadcast %s\n", (*it3).second.GetHash().ToString());
+            LogPrint(BCLog::SYSTEMNODE, "CSystemnodeMan::CheckAndRemove - Removing expired Systemnode broadcast %s\n", (*it3).second.GetHash().ToString());
             systemnodeSync.mapSeenSyncSNB.erase((*it3).second.GetHash());
             mapSeenSystemnodeBroadcast.erase(it3++);
         } else {
@@ -640,5 +322,312 @@ void CSystemnodeMan::CheckAndRemove(bool forceExpiredRemoval)
             ++it4;
         }
     }
+}
 
+void CSystemnodeMan::Clear()
+{
+    LOCK(cs);
+    vSystemnodes.clear();
+    mAskedUsForSystemnodeList.clear();
+    mWeAskedForSystemnodeList.clear();
+    mWeAskedForSystemnodeListEntry.clear();
+    mapSeenSystemnodeBroadcast.clear();
+    mapSeenSystemnodePing.clear();
+}
+
+int CSystemnodeMan::CountEnabled(int protocolVersion)
+{
+    int i = 0;
+    protocolVersion = protocolVersion == -1 ? systemnodePayments.GetMinSystemnodePaymentsProto() : protocolVersion;
+
+    for (auto& sn : vSystemnodes) {
+        sn.Check();
+        if(sn.protocolVersion < protocolVersion || !sn.IsEnabled()) continue;
+        i++;
+    }
+
+    return i;
+}
+
+void CSystemnodeMan::DsegUpdate(CNode* pnode)
+{
+    LOCK(cs);
+
+    if(!(pnode->addr.IsRFC1918() || pnode->addr.IsLocal())){
+        std::map<CNetAddr, int64_t>::iterator it = mWeAskedForSystemnodeList.find(pnode->addr);
+        if (it != mWeAskedForSystemnodeList.end()) {
+            if (GetTime() < (*it).second) {
+                LogPrint(BCLog::SYSTEMNODE, "sndseg - we already asked %s for the list; skipping...\n", pnode->addr.LegacyToString());
+                return;
+            }
+        }
+    }
+
+    const CNetMsgMaker msgMaker(PROTOCOL_VERSION);
+    g_connman->PushMessage(pnode, msgMaker.Make("sndseg", CTxIn()));
+    int64_t askAgain = GetTime() + SYSTEMNODES_DSEG_SECONDS;
+    mWeAskedForSystemnodeList[pnode->addr] = askAgain;
+}
+
+CSystemnode *CSystemnodeMan::Find(const CTxIn &vin)
+{
+    LOCK(cs);
+
+    for (auto& sn : vSystemnodes) {
+        if(sn.vin.prevout == vin.prevout)
+            return &sn;
+    }
+    return NULL;
+}
+
+CSystemnode *CSystemnodeMan::Find(const CPubKey &pubKeySystemnode)
+{
+    LOCK(cs);
+
+    for (auto& sn : vSystemnodes) {
+        if(sn.pubkey2 == pubKeySystemnode)
+            return &sn;
+    }
+    return NULL;
+}
+
+CSystemnode *CSystemnodeMan::Find(const CService& addr)
+{
+    LOCK(cs);
+
+    for (auto& sn : vSystemnodes) {
+        if(sn.addr == addr)
+            return &sn;
+    }
+    return NULL;
+}
+
+//
+// Deterministically select the oldest/best systemnode to pay on the network
+//
+CSystemnode* CSystemnodeMan::GetNextSystemnodeInQueueForPayment(int nBlockHeight, bool fFilterSigTime, int& nCount)
+{
+    LOCK(cs);
+
+    CSystemnode *pBestSystemnode = NULL;
+    std::vector<std::pair<int64_t, CTxIn> > vecSystemnodeLastPaid;
+
+    /*
+        Make a vector with all of the last paid times
+    */
+
+    int nSnCount = CountEnabled();
+    for (auto& sn : vSystemnodes)
+    {
+        sn.Check();
+        if(!sn.IsEnabled()) continue;
+
+        //it's in the list (up to 8 entries ahead of current block to allow propagation) -- so let's skip it
+        if(systemnodePayments.IsScheduled(sn, nBlockHeight)) continue;
+
+        // For security reasons and for network stability there is a delay to get the first reward.
+        // The time is calculated as a product of 60 block and node count.
+        if(fFilterSigTime && sn.sigTime + (nSnCount * 1 * 60) > GetAdjustedTime()) continue;
+
+        //make sure it has as many confirmations as there are systemnodes
+        if(sn.GetSystemnodeInputAge() < nSnCount) continue;
+
+        vecSystemnodeLastPaid.push_back(std::make_pair(sn.SecondsSincePayment(), sn.vin));
+    }
+
+    nCount = (int)vecSystemnodeLastPaid.size();
+
+    //when the network is in the process of upgrading, don't penalize nodes that recently restarted
+    if(fFilterSigTime && nCount < nSnCount / 3) return GetNextSystemnodeInQueueForPayment(nBlockHeight, false, nCount);
+
+    // Sort them high to low
+    sort(vecSystemnodeLastPaid.rbegin(), vecSystemnodeLastPaid.rend(), CompareLastPaid());
+
+    // Look at 1/10 of the oldest nodes (by last payment), calculate their scores and pay the best one
+    //  -- This doesn't look at who is being paid in the +8-10 blocks, allowing for double payments very rarely
+    //  -- 1/100 payments should be a double payment on mainnet - (1/(3000/10))*2
+    //  -- (chance per block * chances before IsScheduled will fire)
+    int nTenthNetwork = CountEnabled() / 10;
+    int nCountTenth = 0;
+    arith_uint256 nHigh = 0;
+    for (auto& s : vecSystemnodeLastPaid) {
+        CSystemnode* pmn = Find(s.second);
+        if(!pmn) break;
+
+        arith_uint256 n = pmn->CalculateScore(nBlockHeight - 100);
+        if(n > nHigh){
+            nHigh = n;
+            pBestSystemnode = pmn;
+        }
+        nCountTenth++;
+        if(nCountTenth >= nTenthNetwork) break;
+    }
+    return pBestSystemnode;
+}
+
+bool CSystemnodeMan::Add(CSystemnode &sn)
+{
+    LOCK(cs);
+
+    if (!sn.IsEnabled())
+        return false;
+
+    CSystemnode *psn = Find(sn.vin);
+    if (!psn) {
+        LogPrint(BCLog::SYSTEMNODE, "CSystemnodeMan: Adding new Systemnode %s - %i now\n", sn.addr.ToString(), size() + 1);
+        vSystemnodes.push_back(sn);
+        return true;
+    }
+
+    return false;
+}
+
+void CSystemnodeMan::UpdateSystemnodeList(CSystemnodeBroadcast snb)
+{
+    auto snbHash = snb.GetHash();
+    mapSeenSystemnodePing.insert(std::make_pair(snb.lastPing.GetHash(), snb.lastPing));
+    mapSeenSystemnodeBroadcast.insert(std::make_pair(snbHash, snb));
+    systemnodeSync.AddedSystemnodeList(snbHash);
+
+    LogPrint(BCLog::SYSTEMNODE, "CSystemnodeMan::UpdateSystemnodeList() - addr: %s\n    vin: %s\n", snb.addr.ToString(), snb.vin.ToString());
+
+    CSystemnode* psn = Find(snb.vin);
+    if (!psn) {
+        CSystemnode sn(snb);
+        Add(sn);
+    } else {
+        psn->UpdateFromNewBroadcast(snb);
+    }
+}
+
+void CSystemnodeMan::Remove(CTxIn vin)
+{
+    LOCK(cs);
+
+    std::vector<CSystemnode>::iterator it = vSystemnodes.begin();
+    while(it != vSystemnodes.end()){
+        if((*it).vin == vin){
+            LogPrint(BCLog::NET, "CSystemnodeMan: Removing Systemnode %s - %i now\n", (*it).addr.ToString(), size() - 1);
+            vSystemnodes.erase(it);
+            break;
+        }
+        ++it;
+    }
+}
+
+std::string CSystemnodeMan::ToString() const
+{
+    std::ostringstream info;
+
+    info << "Systemnodes: " << (int)vSystemnodes.size() <<
+            ", peers who asked us for Systemnode list: " << (int)mAskedUsForSystemnodeList.size() <<
+            ", peers we asked for Systemnode list: " << (int)mWeAskedForSystemnodeList.size() <<
+            ", entries in Systemnode list we asked for: " << (int)mWeAskedForSystemnodeListEntry.size();
+
+    return info.str();
+}
+
+CSystemnode* CSystemnodeMan::GetCurrentSystemNode(int mod, int64_t nBlockHeight, int minProtocol)
+{
+    int64_t score = 0;
+    CSystemnode* winner = NULL;
+
+    // scan for winner
+    for (auto& mn : vSystemnodes) {
+        mn.Check();
+        if(mn.protocolVersion < minProtocol || !mn.IsEnabled()) continue;
+
+        // calculate the score for each Systemnode
+        int64_t n2 = mn.CalculateScore(nBlockHeight).GetCompact(false);
+
+        // determine the winner
+        if(n2 > score){
+            score = n2;
+            winner = &mn;
+        }
+    }
+
+    return winner;
+}
+
+int CSystemnodeMan::GetSystemnodeRank(const CTxIn& vin, int64_t nBlockHeight, int minProtocol, bool fOnlyActive)
+{
+    std::vector<std::pair<int64_t, CTxIn> > vecSystemnodeScores;
+
+    //make sure we know about this block
+    uint256 hash = uint256();
+    if(!GetBlockHash(hash, nBlockHeight)) return -1;
+
+    // scan for winner
+    for (auto& sn : vSystemnodes) {
+        if(sn.protocolVersion < minProtocol) continue;
+        if(fOnlyActive) {
+            sn.Check();
+            if(!sn.IsEnabled()) continue;
+        }
+        int64_t n2 = sn.CalculateScore(nBlockHeight).GetCompact(false);
+
+        vecSystemnodeScores.push_back(std::make_pair(n2, sn.vin));
+    }
+
+    sort(vecSystemnodeScores.rbegin(), vecSystemnodeScores.rend(), CompareScoreTxIn());
+
+    int rank = 0;
+    for (auto& s : vecSystemnodeScores) {
+        rank++;
+        if(s.second.prevout == vin.prevout) {
+            return rank;
+        }
+    }
+
+    return -1;
+}
+
+bool CSystemnodeMan::CheckSnbAndUpdateSystemnodeList(CSystemnodeBroadcast snb, int& nDos)
+{
+    nDos = 0;
+    LogPrint(BCLog::SYSTEMNODE, "CSystemnodeMan::CheckSnbAndUpdateSystemnodeList - Systemnode broadcast, vin: %s\n", snb.vin.ToString());
+
+    auto snbHash = snb.GetHash();
+    if(mapSeenSystemnodeBroadcast.count(snbHash)) { //seen
+        systemnodeSync.AddedSystemnodeList(snbHash);
+        return true;
+    }
+    mapSeenSystemnodeBroadcast.insert(std::make_pair(snbHash, snb));
+
+    LogPrint(BCLog::SYSTEMNODE, "CSystemnodeMan::CheckSnbAndUpdateSystemnodeList - Systemnode broadcast, vin: %s new\n", snb.vin.ToString());
+    // We check addr before both initial snb and update
+    if(!snb.IsValidNetAddr()) {
+        LogPrint(BCLog::SYSTEMNODE, "CMasternodeBroadcast::CheckSnbAndUpdateMasternodeList -- Invalid addr, rejected: masternode=%s  sigTime=%lld  addr=%s\n",
+            snb.vin.prevout.ToStringShort(), snb.sigTime, snb.addr.ToString());
+        return false;
+    }
+
+    if (mnodeman.Find(snb.addr) != NULL) {
+        LogPrint(BCLog::SYSTEMNODE, "CSystemnodeMan::CheckSnbAndUpdateSystemnodeList - There is already a masternode with the same ip: %s\n", snb.addr.ToString());
+        return false;
+    }
+
+    if(!snb.CheckAndUpdate(nDos)) {
+        LogPrint(BCLog::SYSTEMNODE, "CSystemnodeMan::CheckSnbAndUpdateSystemnodeList - Systemnode broadcast, vin: %s CheckAndUpdate failed\n", snb.vin.ToString());
+        return false;
+    }
+
+    // make sure the vout that was signed is related to the transaction that spawned the Systemnode
+    //  - this is expensive, so it's only done once per Systemnode
+    if (!legacySigner.IsVinAssociatedWithPubkey(snb.vin, snb.pubkey, 1, Params().GetConsensus())) {
+        LogPrint(BCLog::SYSTEMNODE, "CSystemnodeMan::CheckSnbAndUpdateSystemnodeList - Got mismatched pubkey and vin\n");
+        return false;
+    }
+
+    // make sure it's still unspent
+    //  - this is checked later by .check() in many places and by ThreadCheckDarkSendPool()
+    if(snb.CheckInputsAndAdd(nDos)) {
+        systemnodeSync.AddedSystemnodeList(snbHash);
+    } else {
+        LogPrint(BCLog::SYSTEMNODE, "CSystemnodeMan::CheckSnbAndUpdateSystemnodeList - Rejected Systemnode entry %s\n", snb.addr.ToString());
+        return false;
+    }
+
+    return true;
 }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1340,7 +1340,7 @@ static void MaybePushAddress(UniValue & entry, const CTxDestination &dest)
  * @param  filter_ismine  The "is mine" filter flags.
  * @param  filter_label   Optional label string to filter incoming transactions.
  */
-static void ListTransactions(const CWallet* const pwallet, const CWalletTx& wtx, int nMinDepth, bool fLong, UniValue& ret, const isminefilter& filter_ismine, const std::string* filter_label) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
+static void ListTransactions(const CWallet* const pwallet, const CWalletTx& wtx, int nMinDepth, bool fLong, UniValue& ret, const isminefilter& filter_ismine, const std::string* filter_label, bool unconfirmed = false) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
 {
     CAmountMap mapFee;
     std::list<COutputEntry> listReceived;
@@ -1349,6 +1349,7 @@ static void ListTransactions(const CWallet* const pwallet, const CWalletTx& wtx,
     wtx.GetAmounts(listReceived, listSent, mapFee, filter_ismine);
 
     bool involvesWatchonly = wtx.IsFromMe(ISMINE_WATCH_ONLY);
+    int confirms = wtx.GetDepthInMainChain();
 
     // Sent
     if (!filter_label)
@@ -1372,6 +1373,10 @@ static void ListTransactions(const CWallet* const pwallet, const CWalletTx& wtx,
             if (fLong)
                 WalletTxToJSON(pwallet->chain(), wtx, entry);
             entry.pushKV("abandoned", wtx.isAbandoned());
+
+            if(unconfirmed && confirms > 0)
+                continue;
+
             ret.push_back(entry);
         }
     }
@@ -1414,6 +1419,10 @@ static void ListTransactions(const CWallet* const pwallet, const CWalletTx& wtx,
             entry.pushKV("vout", r.vout);
             if (fLong)
                 WalletTxToJSON(pwallet->chain(), wtx, entry);
+
+            if(unconfirmed && confirms > 0)
+                continue;
+
             ret.push_back(entry);
         }
     }


### PR DESCRIPTION
<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/crown-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Crown Core user experience or Crown Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Crown Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Crown Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
