### PR TITLE
temp

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -112,8 +112,8 @@ void AddCoins(CCoinsViewCache& cache, const CTransaction &tx, int nHeight, bool 
 			// Coinbase transactions can always be overwritten, in order to correctly
 			// deal with the pre-BIP30 occurrences of duplicate coinbase transactions.
 			//LogPrintf("%s: %s\n", __func__, tx.vpout[i].ToString());
-			//if(!tx.vpout[i].IsEmpty())
-			cache.AddCoin(COutPoint(txid, i), Coin(tx.vpout[i], nHeight, fCoinbase, fCoinstake), overwrite);
+			if(!tx.vpout[i].IsEmpty())
+			    cache.AddCoin(COutPoint(txid, i), Coin(tx.vpout[i], nHeight, fCoinbase, fCoinstake), overwrite);
 		}
 	}
 	else{

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1938,8 +1938,8 @@ DisconnectResult CChainState::DisconnectBlock(const CBlock& block, const CBlockI
                     Coin coin;
                     bool is_spent = view.SpendCoin(out, &coin);
                     if (!is_spent || tx.vpout[o] != coin.out || pindex->nHeight != coin.nHeight || is_coinbase != coin.fCoinBase || is_coinstake != coin.fCoinStake) {
-                        //if(!tx.vpout[o].IsEmpty())
-                        fClean = false; // transaction output mismatch
+                        if(!tx.vpout[o].IsEmpty())
+                            fClean = false; // transaction output mismatch
                         //LogPrintf("fClean %s , SPENT %s , OUT %s, CB %s, CS %s\n", fClean ? "true": "false", is_spent ? "true": "false", tx.vpout[o] != coin.out ? "true": "false", is_coinbase != coin.fCoinBase ? "true": "false",is_coinstake != coin.fCoinStake ? "true": "false");
                         //LogPrintf("VOUT %s \n %s \n", tx.vpout[o].ToString(), coin.out.ToString());
                     }


### PR DESCRIPTION
<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/crown-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Crown Core user experience or Crown Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Crown Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Crown Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
