### PR TITLE
DDD

### DIFF
--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -217,8 +217,8 @@ public:
         return ::GetAllAssets();
     }
 
-    void startStake(bool fStake, CWallet *pwallet, std::thread* stakeThread)override{
-        ::Stake(fStake, pwallet, stakeThread);
+    void startStake(bool fStake, CWallet *pwallet)override{
+        ::Stake(fStake, pwallet);
     }
 
     CContract getContract(std::string name) override

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -94,7 +94,7 @@ public:
     virtual CAsset getAsset(std::string sAssetName) = 0;
     virtual std::vector<CAsset> getAllAssets() =0;
     virtual CTxMemPool& getMempool() = 0;
-    virtual void startStake(bool fStake, CWallet *pwallet, std::thread* stakeThread) = 0;
+    virtual void startStake(bool fStake, CWallet *pwallet) = 0;
     //! Get block height above genesis block. Returns 0 for genesis block,
     //! 1 for following block, and so on. Returns nullopt for a block not
     //! included in the current chain.

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -682,16 +682,24 @@ void ThreadStakeMiner(CWallet *pwallet)
     LogPrintf("ThreadStakeMiner exiting\n");
 }
 
-void Stake(bool fStake, CWallet *pwallet, std::thread* stakeThread)
+std::thread* stakeThread = nullptr;
+
+void Stake(bool fStake, CWallet *pwallet)
 {
     if (stakeThread != nullptr)
     {
+        LogPrintf("%s: Destroying Stake thread\n", __func__);
+
         if (stakeThread->joinable())
             stakeThread->join();
         stakeThread = nullptr;
+        LogPrintf("%s: Stake thread destroyed \n", __func__);
+
     }
     if(fStake)
     {
+        LogPrintf("%s: Creating Stake thread\n", __func__);
+
         stakeThread = new std::thread([&, pwallet] { TraceThread("stake", [&, pwallet] { ThreadStakeMiner(pwallet); }); });
     }
 }

--- a/src/miner.h
+++ b/src/miner.h
@@ -198,7 +198,7 @@ private:
     int UpdatePackagesForAdded(const CTxMemPool::setEntries& alreadyAdded, indexed_modified_transaction_set& mapModifiedTx) EXCLUSIVE_LOCKS_REQUIRED(m_mempool.cs);
 };
 /** Generate a new block, without valid proof-of-work */
-void Stake(bool fStake, CWallet *pwallet, std::thread* stakeThread);
+void Stake(bool fStake, CWallet *pwallet);
 
 /** Modify the extranonce in a block */
 void IncrementExtraNonce(CBlock* pblock, const CBlockIndex* pindexPrev, unsigned int& nExtraNonce);

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -73,6 +73,9 @@ void WalletInit::AddWalletOptions(ArgsManager& argsman) const
     argsman.AddArg("-privdb", strprintf("Sets the DB_PRIVATE flag in the wallet db environment (default: %u)", DEFAULT_WALLET_PRIVDB), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::WALLET_DEBUG_TEST);
     argsman.AddArg("-walletrejectlongchains", strprintf("Wallet will not create transactions that violate mempool chain limits (default: %u)", DEFAULT_WALLET_REJECT_LONG_CHAINS), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::WALLET_DEBUG_TEST);
 
+    argsman.AddArg("-stake", strprintf("Run a thread for staking default: %u)", true), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
+
+
     argsman.AddHiddenArgs({"-zapwallettxes"});
 }
 

--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -124,6 +124,7 @@ void StartWallets(CScheduler& scheduler, const ArgsManager& args)
 {
     for (const std::shared_ptr<CWallet>& pwallet : GetWallets()) {
         pwallet->postInitProcess();
+        if (args.GetBoolArg("-stake", true))
             pwallet->Stake(true);
     }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -345,8 +345,6 @@ std::shared_ptr<CWallet> CreateWallet(interfaces::Chain& chain, const std::strin
     AddWallet(wallet);
     wallet->postInitProcess();
 
-        wallet->Stake(true);
-
     // Write the wallet settings
     UpdateWalletSetting(chain, name, load_on_start, warnings);
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -772,8 +772,6 @@ private:
      */
     uint256 m_last_block_processed GUARDED_BY(cs_wallet);
 
-    std::thread* stakeThread = nullptr;
-
     /* Height of last block processed is used by wallet to know depth of transactions
      * without relying on Chain interface beyond asynchronous updates. For safety, we
      * initialize it to -1. Height is a pointer on node's tip and doesn't imply


### PR DESCRIPTION
<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/crown-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Crown Core user experience or Crown Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Crown Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Crown Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
